### PR TITLE
Fix tests on step 18.1

### DIFF
--- a/tests/Controller/ConferenceControllerTest.php
+++ b/tests/Controller/ConferenceControllerTest.php
@@ -35,7 +35,7 @@ class ConferenceControllerTest extends WebTestCase
         self::$container->get(EntityManagerInterface::class)->flush();
 
         $client->followRedirect();
-        $this->assertSelectorExists('div:contains("There are 2 comments")');
+        $this->assertSelectorExists('div:contains("There are 3 comments")');
     }
 
     public function testConferencePage()
@@ -50,6 +50,6 @@ class ConferenceControllerTest extends WebTestCase
         $this->assertPageTitleContains('Amsterdam');
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h2', 'Amsterdam 2019');
-        $this->assertSelectorExists('div:contains("There are 1 comments")');
+        $this->assertSelectorExists('div:contains("There are 2 comments")');
     }
 }


### PR DESCRIPTION
This PR fixes tests (`\App\Tests\Controller\ConferenceControllerTest`) on step 18.1.
On the step was added new comment to fixtures, but the comment does not use in tests